### PR TITLE
Add export statements for classes Database and Collection for usage as types

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -52,7 +52,7 @@ export class MongoClient {
   }
 }
 
-class Database {
+export class Database {
   name: string;
   client: MongoClient;
 
@@ -66,7 +66,7 @@ class Database {
   }
 }
 
-class Collection<T> {
+export class Collection<T> {
   name: string;
   database: Database;
   client: MongoClient;


### PR DESCRIPTION
In my own project I created the following class to have every database-related functionality in one place:

```js
import { MongoClient, ObjectId } from "$atlas_sdk/mod.ts";

export class MongoDBDatabase {
  client: MongoClient;
  db;
  users;

  constructor() {
    this.client = new MongoClient({ ...  });
    this.db = this.client.database("db");
    this.users = this.db.collection<UserSchema>("users");
  }

  async insertUser(email: string, username: string) {
    const result = await this.users.insertOne({
      email,
      username
    });
    return result;
  }

  async getUserByEmail(email: string) {
    ...
  }

  ...
}
```

I was able to set the correct type for `client` as `MongoClient`, but since export statements were missing I couldn't set the types for `db` and `users` to `Database` and `Collection` respectively:

```js
import { MongoClient, Database, Collection, ... } from "$atlas_sdk/mod.ts";

...
export class MongoDBDatabase {
  client: MongoClient;
  db: Database;
  users: Collection;
  ...
}
```