### PR TITLE
Error fix "Expected 3 arguments, but got 2." for updateOne(), updateMany() and replaceOne()

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -118,7 +118,7 @@ export class Collection<T> {
   updateOne(
     filter: Document,
     update: Document,
-    { upsert }: { upsert?: boolean },
+    upsert = false,
   ): Promise<
     { matchedCount: number; modifiedCount: number; upsertedId?: string }
   > {
@@ -132,7 +132,7 @@ export class Collection<T> {
   updateMany(
     filter: Document,
     update: Document,
-    { upsert }: { upsert?: boolean },
+    upsert = false,
   ): Promise<
     { matchedCount: number; modifiedCount: number; upsertedId?: string }
   > {
@@ -146,7 +146,7 @@ export class Collection<T> {
   replaceOne(
     filter: Document,
     replacement: Document,
-    { upsert }: { upsert?: boolean },
+    upsert = false,
   ): Promise<
     { matchedCount: number; modifiedCount: number; upsertedId?: string }
   > {

--- a/client.ts
+++ b/client.ts
@@ -118,7 +118,7 @@ export class Collection<T> {
   updateOne(
     filter: Document,
     update: Document,
-    upsert = false,
+    { upsert }: { upsert?: boolean } = {},
   ): Promise<
     { matchedCount: number; modifiedCount: number; upsertedId?: string }
   > {
@@ -132,7 +132,7 @@ export class Collection<T> {
   updateMany(
     filter: Document,
     update: Document,
-    upsert = false,
+    { upsert }: { upsert?: boolean } = {},
   ): Promise<
     { matchedCount: number; modifiedCount: number; upsertedId?: string }
   > {
@@ -146,7 +146,7 @@ export class Collection<T> {
   replaceOne(
     filter: Document,
     replacement: Document,
-    upsert = false,
+    { upsert }: { upsert?: boolean } = {},
   ): Promise<
     { matchedCount: number; modifiedCount: number; upsertedId?: string }
   > {


### PR DESCRIPTION
Error fix `Expected 3 arguments, but got 2.` when using `updateOne()`, `updateMany()` and `replaceOne()` as described in docs.

![Bildschirmfoto 2022-07-23 um 15 52 32](https://user-images.githubusercontent.com/19251998/180608037-a8a1d9a4-424b-48db-bffe-84553cbdfb4f.png)

