### PR TITLE
chore(mod): include Collection on exported members

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,3 @@
 export * from "./deps.ts";
-export { MongoClient } from "./client.ts";
+export { Collection, MongoClient } from "./client.ts";
 export type { MongoClientConstructorOptions } from "./client.ts";


### PR DESCRIPTION
The Collection class should be an exposable class, so implementors of higher-order components (like templates, base repositories, and similar solutions) can implement them without struggling with typing issues.